### PR TITLE
Iostats cleanup

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@ Alex Schickedanz <alex@ae.cs.uni-frankfurt.de>
 Andreas Beckmann <beckmann@cs.uni-frankfurt.de>
 Ilja Andronov <sni4ok@yandex.ru>
 Johannes Singler <singler@ira.uka.de>
+Manuel Penschuck <manuel@ae.cs.uni-frankfurt.de>
 Raoul Steffen <R-Steffen@gmx.de>
 Roman Dementiev <dementiev@ira.uka.de>
 Timo Bingmann <tb@panthema.net>


### PR DESCRIPTION
This PR contains two changes (sorry, I did not put them into two separate commits :( )
- Used a more modern style (replace trivial fors with STL-algos, removing unnecessary types, get rid of C-style casts and const char*), explicit constructors ...
- Added a scoped_print_iostats similar to scoped_print_timer. I also adopted the STXXL tests accordingly to simplify the code
- foxxll::stats_data now contains a to_stream method which works as the ostream<<-operator, but allows to define a line-prefix, which is useful for automated data analysis to tell apart reports from different sections of the algorithm.