### PR TITLE
Switch to docker-based infrastructure, more recent compilers and test…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,68 +1,85 @@
 language: cpp
-sudo: required
+sudo: false
 
 env:
   global:
     # limit parallel threads (default is 32!)
     - OMP_NUM_THREADS=4
-    - STXXL_TMPDIR=/dev/shm
+    - TMPDIR=/tmp
+    - STXXL_TMPDIR=/tmp
 
 matrix:
-  # gcc-5 builds
   include:
-    - env: CMAKE_CC="gcc-5" CMAKE_CXX="g++-5" CMAKE_FLAGS=""     CMAKE_ARGS="-DCMAKE_BUILD_TYPE=RelWithAssert   -DUSE_OPENMP=ON   -DUSE_GNU_PARALLEL=OFF"
+  # gcc-5 builds
+    - env: CMAKE_CC="gcc-5" CMAKE_CXX="g++-5" CMAKE_FLAGS=""     CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release   -DUSE_OPENMP=ON   -DUSE_GNU_PARALLEL=OFF"
       addons: &gcc5
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - george-edison55-precise-backports # cmake 3.2.3 / doxygen 1.8.3
           packages:
             - g++-5
-            - cmake
-            - cmake-data
-    - env: CMAKE_CC="gcc-5" CMAKE_CXX="g++-5" CMAKE_FLAGS=""     CMAKE_ARGS="-DCMAKE_BUILD_TYPE=RelWithAssert   -DUSE_OPENMP=ON   -DUSE_GNU_PARALLEL=ON"
+    - env: CMAKE_CC="gcc-5" CMAKE_CXX="g++-5" CMAKE_FLAGS=""     CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release   -DUSE_OPENMP=ON   -DUSE_GNU_PARALLEL=ON"
       addons: *gcc5
-    - env: CMAKE_CC="gcc-5" CMAKE_CXX="g++-5" CMAKE_FLAGS=""     CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DUSE_OPENMP=ON   -DUSE_GNU_PARALLEL=OFF"
-      addons: *gcc5
-    - env: CMAKE_CC="gcc-5" CMAKE_CXX="g++-5" CMAKE_FLAGS=""     CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DUSE_OPENMP=ON   -DUSE_GNU_PARALLEL=ON"
-      addons: *gcc5
-      # one 32-bit build
+
+  # gcc-7 builds
+    - env: CMAKE_CC="gcc-7" CMAKE_CXX="g++-7" CMAKE_FLAGS=""     CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DUSE_OPENMP=ON -DUSE_GNU_PARALLEL=OFF"
+      addons: &gcc7
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+    - env: CMAKE_CC="gcc-7" CMAKE_CXX="g++-7" CMAKE_FLAGS=""     CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release -DUSE_OPENMP=ON -DUSE_GNU_PARALLEL=ON"
+      addons: *gcc7
+    - env: CMAKE_CC="gcc-7" CMAKE_CXX="g++-7" CMAKE_FLAGS=""     CMAKE_ARGS="-DCMAKE_BUILD_TYPE=RelWithAssert -DUSE_OPENMP=ON -DUSE_GNU_PARALLEL=OFF"
+      addons: *gcc7
+    - env: CMAKE_CC="gcc-7" CMAKE_CXX="g++-7" CMAKE_FLAGS=""     CMAKE_ARGS="-DCMAKE_BUILD_TYPE=RelWithAssert -DUSE_OPENMP=ON -DUSE_GNU_PARALLEL=ON"
+      addons: *gcc7
+
+  # one 32-bit build
     - env: CMAKE_CC="gcc-5"     CMAKE_CXX="g++-5"     CMAKE_FLAGS="-m32" CMAKE_ARGS="-DCMAKE_BUILD_TYPE=RelWithAssert   -DUSE_GNU_PARALLEL=OFF"
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - george-edison55-precise-backports # cmake 3.2.3 / doxygen 1.8.3
           packages:
             - g++-5-multilib
             - linux-libc-dev:i386
-            - cmake
-            - cmake-data
-      # clang build
+
+  # clang build
     - env: CMAKE_CC="clang-3.9"   CMAKE_CXX="clang++-3.9" CMAKE_FLAGS="" CMAKE_ARGS="-DCMAKE_BUILD_TYPE=RelWithAssert -DUSE_GNU_PARALLEL=OFF"
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.9
-            - george-edison55-precise-backports # cmake 3.2.3 / doxygen 1.8.3
+            - llvm-toolchain-trusty-3.9
           packages:
             - clang-3.9
-            - cmake
-            - cmake-data
+            - g++-5
+            - libiomp-dev
+    - env: CMAKE_CC="clang-5.0"   CMAKE_CXX="clang++-5.0" CMAKE_FLAGS="" CMAKE_ARGS="-DCMAKE_BUILD_TYPE=RelWithAssert -DUSE_GNU_PARALLEL=OFF"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+            - g++-5
+            - libiomp-dev
 
 before_script:
-  # run on ramdisk
-  - echo "disk=/dev/shm/stxxl.###.tmp,2G,syscall unlink" > ~/.stxxl
   - df -h
-
   - mkdir build
   - cd build
   - cmake -DCMAKE_C_COMPILER=$CMAKE_CC -DCMAKE_CXX_COMPILER=$CMAKE_CXX
     -DFOXXLL_BUILD_TESTS=ON -DFOXXLL_TRY_COMPILE_HEADERS=ON
     $CMAKE_ARGS ../
     -DCMAKE_C_FLAGS="$CMAKE_FLAGS" -DCMAKE_CXX_FLAGS="$CMAKE_FLAGS"
-    #-DCMAKE_C_FLAGS="-Wconversion $CMAKE_FLAGS" -DCMAKE_CXX_FLAGS="-Wconversion $CMAKE_FLAGS"
 
 script:
-  - make -j2 && ./tools/foxxll_tool info && ctest
+# Build the library and run tests on three IO subsystems
+- make -j2 VERBOSE=1 &&
+   echo "disk=/tmp/stxxl.###.tmp,256Mi,syscall unlink" > ~/.stxxl && ./tools/foxxll_tool info && ctest &&
+   echo "disk=/tmp/stxxl.###.tmp,256Mi,linuxaio unlink" > ~/.stxxl && ./tools/foxxll_tool info && ctest &&
+   echo "disk=/tmp/stxxl.###.tmp,256Mi,memory" > ~/.stxxl && ./tools/foxxll_tool info && ctest


### PR DESCRIPTION
… more IO-subsystems

This PR only touches the TravisCI configuration; it now uses gcc5, gcc7, clang3.9 and clang5.0 and tests syscall, linuxaio and memory as EM backends. It also fixes a dependency error for the clang configuration and uses Travis' docker system (sudo: false). 

Please be aware that testing linuxaio uncovered a sporadic error in Test 23 (foxxll_test_pool_pair) which I can reproduce on my laptop (but did not look into yet). So this should be no reason not to merge.