### PR TITLE
Byte size literals. Rough sketch

### DIFF
--- a/foxxll/common/literals.hpp
+++ b/foxxll/common/literals.hpp
@@ -1,0 +1,47 @@
+/***************************************************************************
+ *  foxxll/common/literals.hpp
+ *
+ *  Part of the STXXL. See http://stxxl.org
+ *
+ *  Copyright (C) 2018 Manuel Penschuck <foxxll@manuel.jetzt>
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *  (See accompanying file LICENSE_1_0.txt or copy at
+ *  http://www.boost.org/LICENSE_1_0.txt)
+ **************************************************************************/
+
+#ifndef FOXXLL_COMMON_LITERALS_HEADER
+#define FOXXLL_COMMON_LITERALS_HEADER
+
+#include <limits>
+
+#include <foxxll/common/types.hpp>
+
+// external sizes
+constexpr foxxll::external_size_type operator""_eB  (unsigned long long int x) {return x;}
+constexpr foxxll::external_size_type operator""_ekB (unsigned long long int x) {return x*1000u;}
+constexpr foxxll::external_size_type operator""_eMB (unsigned long long int x) {return x*1000_ekB;}
+constexpr foxxll::external_size_type operator""_eGB (unsigned long long int x) {return x*1000_eMB;}
+constexpr foxxll::external_size_type operator""_eTB (unsigned long long int x) {return x*1000_eGB;}
+constexpr foxxll::external_size_type operator""_ePB (unsigned long long int x) {return x*1000_eTB;}
+constexpr foxxll::external_size_type operator""_eKiB(unsigned long long int x) {return x*1024u;}
+constexpr foxxll::external_size_type operator""_eMiB(unsigned long long int x) {return x*1024_eKiB;}
+constexpr foxxll::external_size_type operator""_eGiB(unsigned long long int x) {return x*1024_eMiB;}
+constexpr foxxll::external_size_type operator""_eTiB(unsigned long long int x) {return x*1024_eGiB;}
+constexpr foxxll::external_size_type operator""_ePiB(unsigned long long int x) {return x*1024_eTiB;}
+
+// internal sizes
+constexpr size_t operator""_iB  (unsigned long long int x) {return static_cast<size_t>(x*1_eB  );}
+constexpr size_t operator""_ikB (unsigned long long int x) {return static_cast<size_t>(x*1_ekB );}
+constexpr size_t operator""_iMB (unsigned long long int x) {return static_cast<size_t>(x*1_eMB );}
+constexpr size_t operator""_iGB (unsigned long long int x) {return static_cast<size_t>(x*1_eGB );}
+constexpr size_t operator""_iTB (unsigned long long int x) {return static_cast<size_t>(x*1_eTB );}
+constexpr size_t operator""_iPB (unsigned long long int x) {return static_cast<size_t>(x*1_ePB );}
+constexpr size_t operator""_iKiB(unsigned long long int x) {return static_cast<size_t>(x*1_eKiB);}
+constexpr size_t operator""_iMiB(unsigned long long int x) {return static_cast<size_t>(x*1_eMiB);}
+constexpr size_t operator""_iGiB(unsigned long long int x) {return static_cast<size_t>(x*1_eGiB);}
+constexpr size_t operator""_iTiB(unsigned long long int x) {return static_cast<size_t>(x*1_eTiB);}
+constexpr size_t operator""_iPiB(unsigned long long int x) {return static_cast<size_t>(x*1_ePiB);}
+
+
+#endif // FOXXLL_COMMON_LITERALS_HEADER

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -11,7 +11,9 @@
 ############################################################################
 
 foxxll_build_test(test_uint_types)
+foxxll_build_test(test_literals)
 
 foxxll_test(test_uint_types)
+foxxll_test(test_literals)
 
 ############################################################################

--- a/tests/common/test_literals.cpp
+++ b/tests/common/test_literals.cpp
@@ -1,0 +1,33 @@
+/***************************************************************************
+ *  tests/common/test_literals.cpp
+ *
+ *  Part of the STXXL. See http://stxxl.org
+ *
+ *  Copyright (C) 2018 Manuel Penschuck <foxxll@manuel.jetzt>
+ *
+ *  Distributed under the Boost Software License, Version 1.0.
+ *  (See accompanying file LICENSE_1_0.txt or copy at
+ *  http://www.boost.org/LICENSE_1_0.txt)
+ **************************************************************************/
+
+#include <iostream>
+
+#include <foxxll/common/literals.hpp>
+
+static_assert(1_eB  == 1llu, "");
+static_assert(1_ekB == 1000llu, "");
+static_assert(1_eMB == 1000llu * 1000llu, "");
+static_assert(1_eGB == 1000llu * 1000llu * 1000llu, "");
+static_assert(1_eTB == 1000llu * 1000llu * 1000llu * 1000llu, "");
+static_assert(1_ePB == 1000llu * 1000llu * 1000llu * 1000llu * 1000llu, "");
+static_assert(1_eB  == 1llu, "");
+static_assert(1_eKiB == 1024llu, "");
+static_assert(1_eMiB == 1024llu * 1024llu, "");
+static_assert(1_eGiB == 1024llu * 1024llu * 1024llu, "");
+static_assert(1_eTiB == 1024llu * 1024llu * 1024llu * 1024llu, "");
+static_assert(1_ePiB == 1024llu * 1024llu * 1024llu * 1024llu * 1024llu, "");
+
+int main() {
+    std::cout << "This is a compile-time only test." << std::endl;
+    return 0;
+}

--- a/tests/mng/test_aligned.cpp
+++ b/tests/mng/test_aligned.cpp
@@ -17,9 +17,10 @@
 #include <iostream>
 #include <vector>
 
+#include <foxxll/common/literals.hpp>
 #include <foxxll/mng.hpp>
 
-#define BLOCK_SIZE (512 * 1024)
+constexpr auto BLOCK_SIZE = 512_iKiB;
 
 struct type
 {
@@ -51,12 +52,12 @@ void test_typed_block()
 
 void test_aligned_alloc()
 {
-    void* p = foxxll::aligned_alloc<1024>(4096);
+    void* p = foxxll::aligned_alloc<1_iKiB>(1_iKiB);
     void* q = nullptr;
-    void* r = foxxll::aligned_alloc<1024>(4096, 42);
-    foxxll::aligned_dealloc<1024>(p);
-    foxxll::aligned_dealloc<1024>(q);
-    foxxll::aligned_dealloc<1024>(r);
+    void* r = foxxll::aligned_alloc<1_iKiB>(4_iKiB, 42);
+    foxxll::aligned_dealloc<1_iKiB>(p);
+    foxxll::aligned_dealloc<1_iKiB>(q);
+    foxxll::aligned_dealloc<1_iKiB>(r);
 }
 
 void test_typed_block_vector()


### PR DESCRIPTION
*Don't merge; discuss!*

Do we want to use literals for easier scaling of size types?

Currently, a lot of test programmes and applications use definitions like
```cpp
constexpr auto MiB = 1024 * 1024;
#define MiB (1024 * 1024)
#define MiB (1 << 20)
```

It seems redundant and hard to do this and we should encourage some form to do this.

One variant to go is simply defining these constants, e.g. 
```cpp
namespace foxxll {
constexpr size_t MiB = 1024 * 1024;
}
```

But we either need to drag it into global namespace, or be sure, that nobody uses it (
as it's far easier to write `512*1024` than `512*foxxll::KiB`).

Here's a suggestion to achieve the same thing using literals. As we still distinguish between internal and external size, the PR defines two sets of constants iXXX for internal size and eXXX for external size. This is somewhat strange, since iTB, for instance, is doomed on all 32-bit builds. So it should basically never be used and hence removed????

Nevertheless, I find it nice to be able to write

```cpp
stxxl::sorter<int> sort(512_iMiB, stxxl::comparator<int>());
```



