### PR TITLE
cmake: use correct variable for config path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,7 +507,7 @@ install(DIRECTORY foxxll
 
 # also copy the config file with build options!
 install(FILES ${PROJECT_BINARY_DIR}/foxxll/config.hpp
-  DESTINATION ${INSTALL_INCLUDE_DIR}/foxxll/)
+  DESTINATION ${FOXXLL_INSTALL_INCLUDE_DIR}/foxxll/)
 
 ###############################################################################
 # prepare pkg-config file


### PR DESCRIPTION
Use the `${FOXXLL_INSTALL_INCLUDE_DIR}` variable to set the install destination of `config.hpp`.

This was causing packaging issues for some reason when `${INSTALL_INCLUDE_DIR}` expanded to an empty string (placing the files at root instead).