### PR TITLE
Remove warnings on GCC12

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "extlib/tlx"]
 	path = extlib/tlx
-	url = https://github.com/tlx/tlx.git
+	url = https://github.com/joka921/tlx.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,8 @@ endif()
 
 ###############################################################################
 # enable C++14 and more compiler features
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # more template depth for some tests and compilers
 include(CheckCXXCompilerFlag)
@@ -203,31 +205,18 @@ if(CXX_HAS_TEMPLATE_DEPTH)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftemplate-depth=1024")
 endif()
 
-# enable C++14
-if(MSVC)
-  # TODO: ???
-else()
-  # try -std= flags to enable C++14
-  check_cxx_compiler_flag(-std=c++14 CXX_HAS_STD_CXX14)
-  if(CXX_HAS_STD_CXX14)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-  else()
-    message(SEND_ERROR "Compiler does not support -std=c++14")
-  endif()
 
-  # on MacOSX with clang we need to use libc++ for C++14 headers
-  if(APPLE)
-    if (CMAKE_CXX_COMPILER MATCHES ".*clang[+][+]"
-        OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-      check_cxx_compiler_flag(-stdlib=libc++ CXX_HAS_STDLIB_LIBCXX)
-      if(CXX_HAS_STDLIB_LIBCXX)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-      else()
-        message(SEND_ERROR "Compilation on MacOSX with clang requires libc++.")
-      endif()
+if(APPLE)
+  if (CMAKE_CXX_COMPILER MATCHES ".*clang[+][+]"
+      OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    check_cxx_compiler_flag(-stdlib=libc++ CXX_HAS_STDLIB_LIBCXX)
+    if(CXX_HAS_STDLIB_LIBCXX)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+    else()
+      message(SEND_ERROR "Compilation on MacOSX with clang requires libc++.")
     endif()
-  endif(APPLE)
-endif()
+  endif()
+endif(APPLE)
 
 ###############################################################################
 # enable gcov coverage analysis with gcc

--- a/foxxll/io/request_interface.hpp
+++ b/foxxll/io/request_interface.hpp
@@ -57,9 +57,13 @@ public:
     //! non-copyable: delete copy-constructor
     request_interface(const request_interface&) = delete;
     //! non-copyable: delete assignment operator
-    request_interface& operator = (const request_interface&) = delete;
+    request_interface& operator=(const request_interface&) = delete;
+    //! moveable: default move-constructor
+    request_interface(request_interface&&) = default;
+    //! moveable: default move-assignment
+    request_interface& operator=(request_interface&&) = default;
 
-    virtual ~request_interface() { }
+    virtual ~request_interface() {}
 
     //! Suspends calling thread until completion of the request.
     virtual void wait(bool measure_time = true) = 0;

--- a/foxxll/io/request_queue_impl_1q.cpp
+++ b/foxxll/io/request_queue_impl_1q.cpp
@@ -73,7 +73,7 @@ void request_queue_impl_1q::add_request(request_ptr& req)
         std::unique_lock<std::mutex> lock(queue_mutex_);
         if (std::find_if(
                 queue_.begin(), queue_.end(),
-                bind2nd(file_offset_match(), req)
+                [&](const auto& el){return file_offset_match{}(el, req);}
             )
             != queue_.end())
         {

--- a/foxxll/io/request_queue_impl_1q.cpp
+++ b/foxxll/io/request_queue_impl_1q.cpp
@@ -34,7 +34,6 @@
 namespace foxxll {
 
 struct file_offset_match
-    : public std::binary_function<request_ptr, request_ptr, bool>
 {
     bool operator () (
         const request_ptr& a,

--- a/foxxll/io/request_queue_impl_qwqr.cpp
+++ b/foxxll/io/request_queue_impl_qwqr.cpp
@@ -34,7 +34,6 @@ namespace foxxll {
 
 
 struct file_offset_match
-    : public std::binary_function<request_ptr, request_ptr, bool>
 {
     bool operator () (
         const request_ptr& a,

--- a/foxxll/io/request_queue_impl_qwqr.cpp
+++ b/foxxll/io/request_queue_impl_qwqr.cpp
@@ -32,6 +32,7 @@
 
 namespace foxxll {
 
+
 struct file_offset_match
     : public std::binary_function<request_ptr, request_ptr, bool>
 {
@@ -74,7 +75,7 @@ void request_queue_impl_qwqr::add_request(request_ptr& req)
             std::unique_lock<std::mutex> lock(write_mutex_);
             if (std::find_if(
                     write_queue_.begin(), write_queue_.end(),
-                    bind2nd(file_offset_match(), req)
+                    [&](const auto& x) { return file_offset_match{}(x, req);}
                 )
                 != write_queue_.end())
             {
@@ -92,7 +93,7 @@ void request_queue_impl_qwqr::add_request(request_ptr& req)
             std::unique_lock<std::mutex> lock(read_mutex_);
             if (std::find_if(
                     read_queue_.begin(), read_queue_.end(),
-                    bind2nd(file_offset_match(), req)
+                    [&](const auto& x) { return file_offset_match{}(x, req);}
                 )
                 != read_queue_.end())
             {

--- a/foxxll/io/request_with_waiters.cpp
+++ b/foxxll/io/request_with_waiters.cpp
@@ -49,7 +49,7 @@ void request_with_waiters::notify_waiters()
     std::unique_lock<std::mutex> lock(waiters_mutex_);
     std::for_each(
         waiters_.begin(), waiters_.end(),
-        std::mem_fun(&onoff_switch::on)
+        std::mem_fn(&onoff_switch::on)
     );
 }
 

--- a/foxxll/mng/async_schedule.cpp
+++ b/foxxll/mng/async_schedule.cpp
@@ -43,7 +43,7 @@ struct sim_event
     inline sim_event(size_t t, size_t b) : timestamp(t), iblock(b) { }
 };
 
-struct sim_event_cmp : public std::binary_function<sim_event, sim_event, bool>
+struct sim_event_cmp
 {
     inline bool operator () (const sim_event& a, const sim_event& b) const
     {
@@ -52,7 +52,7 @@ struct sim_event_cmp : public std::binary_function<sim_event, sim_event, bool>
 };
 
 using write_time_pair = std::pair<size_t, size_t>;
-struct write_time_cmp : public std::binary_function<write_time_pair, write_time_pair, bool>
+struct write_time_cmp
 {
     inline bool operator () (const write_time_pair& a, const write_time_pair& b) const
     {

--- a/foxxll/mng/block_alloc_strategy.hpp
+++ b/foxxll/mng/block_alloc_strategy.hpp
@@ -134,7 +134,9 @@ private:
         for (size_t i = 0; i < diff_; i++)
             perm_[i] = i;
 
-        std::random_shuffle(perm_.begin(), perm_.end());
+        std::random_device rd;
+        std::mt19937 g(rd());
+        std::shuffle(perm_.begin(), perm_.end(), g);
     }
 
 public:

--- a/foxxll/mng/block_alloc_strategy_interleaved.hpp
+++ b/foxxll/mng/block_alloc_strategy_interleaved.hpp
@@ -92,7 +92,9 @@ struct interleaved_random_cyclic : public interleaved_striping
             for (size_t j = 0; j < diff_; j++)
                 perms_[i][j] = j;
 
-            std::random_shuffle(perms_[i].begin(), perms_[i].end());
+            std::random_device rd;
+            std::mt19937 g(rd());
+            std::shuffle(perms_[i].begin(), perms_[i].end(), g);
         }
     }
 


### PR DESCRIPTION
Remove usages of `std::binary_function`, which is not needed anymore and has been removed from the C++ standard.